### PR TITLE
dev

### DIFF
--- a/chemrust-nasl-app/Cargo.toml
+++ b/chemrust-nasl-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chemrust-nasl-app"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["TonyWu20"]
 

--- a/chemrust-nasl-app/src/execution/export.rs
+++ b/chemrust-nasl-app/src/execution/export.rs
@@ -16,24 +16,30 @@ pub fn export_all<T: UnitCellParameters>(
     results: &SearchReports,
 ) -> Result<(), IoError> {
     if let Some(multi_points) = results.points() {
-        let boundary_checked: Vec<MultiCoordPoint> = boundary_check(multi_points, cell_param);
+        let boundary_checked: Vec<MultiCoordPoint> =
+            points_boundary_check(multi_points, cell_param);
         export(base_model, cell_param, task_config, &boundary_checked)?;
         collectively_export(base_model, cell_param, task_config, &boundary_checked)?;
     }
     if let Some(single_points) = results.viable_single_points() {
-        let boundary_checked: Vec<DelegatePoint> = boundary_check(single_points, cell_param);
+        let boundary_checked: Vec<DelegatePoint<1>> =
+            points_boundary_check(single_points, cell_param);
         export(base_model, cell_param, task_config, &boundary_checked)?;
         collectively_export(base_model, cell_param, task_config, &boundary_checked)?;
     }
     if let Some(double_points) = results.viable_double_points() {
-        let boundary_checked: Vec<DelegatePoint> = boundary_check(single_points, cell_param);
+        let boundary_checked: Vec<DelegatePoint<2>> =
+            points_boundary_check(double_points, cell_param);
         export(base_model, cell_param, task_config, &boundary_checked)?;
         collectively_export(base_model, cell_param, task_config, &boundary_checked)?;
     }
     Ok(())
 }
 
-fn boundary_check<T: Visualize, U: UnitCellParameters>(points: &[T], cell_param: &U) -> Vec<T> {
+fn points_boundary_check<T: Visualize + Clone, U: UnitCellParameters>(
+    points: &[T],
+    cell_param: &U,
+) -> Vec<T> {
     points
         .iter()
         .filter(|cp| {

--- a/chemrust-nasl-app/src/execution/export.rs
+++ b/chemrust-nasl-app/src/execution/export.rs
@@ -5,7 +5,7 @@ use std::{fs::create_dir, io::Error as IoError};
 
 use castep_cell_io::{CellDocument, IonicPosition};
 use chemrust_core::data::lattice::cell_param::UnitCellParameters;
-use chemrust_nasl::{CoordPoint, CoordSite, SearchReports, Visualize};
+use chemrust_nasl::{CoordSite, DelegatePoint, MultiCoordPoint, SearchReports, Visualize};
 
 use crate::yaml_parser::TaskTable;
 
@@ -15,35 +15,40 @@ pub fn export_all<T: UnitCellParameters>(
     task_config: &TaskTable,
     results: &SearchReports,
 ) -> Result<(), IoError> {
-    if !results.spheres().is_empty() {
-        export(base_model, cell_param, task_config, results.spheres())?;
-        collectively_export(base_model, cell_param, task_config, results.spheres())?;
+    if let Some(multi_points) = results.points() {
+        let boundary_checked: Vec<MultiCoordPoint> = boundary_check(multi_points, cell_param);
+        export(base_model, cell_param, task_config, &boundary_checked)?;
+        collectively_export(base_model, cell_param, task_config, &boundary_checked)?;
     }
-    if !results.circles().is_empty() {
-        export(base_model, cell_param, task_config, results.circles())?;
-        collectively_export(base_model, cell_param, task_config, results.circles())?;
+    if let Some(single_points) = results.viable_single_points() {
+        let boundary_checked: Vec<DelegatePoint> = boundary_check(single_points, cell_param);
+        export(base_model, cell_param, task_config, &boundary_checked)?;
+        collectively_export(base_model, cell_param, task_config, &boundary_checked)?;
     }
-    if !results.points().is_empty() {
-        let boundary_checked: Vec<CoordPoint> = results
-            .points()
-            .iter()
-            .filter(|cp| {
-                let frac_coord = cp.fractional_coord(cell_param.cell_tensor());
-                let check = frac_coord.iter().try_for_each(|&v| {
-                    if !(0.0..=1.0).contains(&v) {
-                        ControlFlow::Break(v)
-                    } else {
-                        ControlFlow::Continue(())
-                    }
-                });
-                matches!(check, ControlFlow::Continue(()))
-            })
-            .cloned()
-            .collect();
+    if let Some(double_points) = results.viable_double_points() {
+        let boundary_checked: Vec<DelegatePoint> = boundary_check(single_points, cell_param);
         export(base_model, cell_param, task_config, &boundary_checked)?;
         collectively_export(base_model, cell_param, task_config, &boundary_checked)?;
     }
     Ok(())
+}
+
+fn boundary_check<T: Visualize, U: UnitCellParameters>(points: &[T], cell_param: &U) -> Vec<T> {
+    points
+        .iter()
+        .filter(|cp| {
+            let frac_coord = cp.fractional_coord(cell_param.cell_tensor());
+            let check = frac_coord.iter().try_for_each(|&v| {
+                if !(0.0..=1.0).contains(&v) {
+                    ControlFlow::Break(())
+                } else {
+                    ControlFlow::Continue(())
+                }
+            });
+            matches!(check, ControlFlow::Continue(()))
+        })
+        .cloned()
+        .collect::<Vec<T>>()
 }
 
 fn export_filename<T: CoordSite>(coord_site: &T, task_config: &TaskTable) -> PathBuf {

--- a/chemrust-nasl-app/src/execution/helpers.rs
+++ b/chemrust-nasl-app/src/execution/helpers.rs
@@ -15,10 +15,11 @@ use super::{
 };
 
 pub fn boundary_check(v: f64) -> f64 {
-    if v < 0.0 {
-        v + 1.0
-    } else if v > 1.0 {
-        v - 1.0
+    if !(0.0..=1.0).contains(&v) {
+        // If v = -0.9, then returns -0.9 - (-1.0) = 0.1
+        // If v = -3.8, then returns -3.8 - (-4.0) = 0.2
+        // If v = 2.8 then returns 2.8 - 2.0 = 0.8
+        v - v.floor()
     } else {
         v
     }

--- a/chemrust-nasl-app/src/execution/mod.rs
+++ b/chemrust-nasl-app/src/execution/mod.rs
@@ -6,7 +6,9 @@ use chemrust_core::data::{
     geom::coordinates::CoordData,
     lattice::{cell_param::UnitCellParameters, CrystalModel},
 };
-use chemrust_nasl::{search_sites, SearchConfig, SearchReports, SearchResults, SiteIndex};
+use chemrust_nasl::{
+    search_sites, search_special_sites, SearchConfig, SearchReports, SearchResults, SiteIndex,
+};
 use nalgebra::Point3;
 
 use crate::yaml_parser::TaskTable;
@@ -45,21 +47,7 @@ pub fn search(task_config: &TaskTable) -> Result<SearchResults, Box<dyn Error>> 
         .collect();
     let site_index = SiteIndex::new(points);
     let search_config = SearchConfig::new(&to_check, task_config.target_bondlength());
-    let search_sites = search_sites(&site_index, &search_config);
-    #[cfg(debug_assertions)]
-    {
-        if let SearchResults::Found(report) = &search_sites {
-            let validated_spheres =
-                SearchReports::validated_results(report.spheres(), &site_index, &search_config);
-            dbg!(validated_spheres.len(), report.spheres().len());
-            let validated_circles =
-                SearchReports::validated_results(report.circles(), &site_index, &search_config);
-            dbg!(validated_circles.len(), report.circles().len());
-            let validated_points =
-                SearchReports::validated_results(report.points(), &site_index, &search_config);
-            dbg!(validated_points.len(), report.points().len());
-        }
-    }
+    let search_report = search_sites(&site_index, &search_config);
     Ok(search_sites)
 }
 

--- a/chemrust-nasl-app/src/execution/mod.rs
+++ b/chemrust-nasl-app/src/execution/mod.rs
@@ -6,9 +6,7 @@ use chemrust_core::data::{
     geom::coordinates::CoordData,
     lattice::{cell_param::UnitCellParameters, CrystalModel},
 };
-use chemrust_nasl::{
-    search_sites, search_special_sites, SearchConfig, SearchReports, SearchResults, SiteIndex,
-};
+use chemrust_nasl::{search_sites, SearchConfig, SearchReports, SiteIndex};
 use nalgebra::Point3;
 
 use crate::yaml_parser::TaskTable;
@@ -24,7 +22,7 @@ mod format_identify;
 mod format_loader;
 mod helpers;
 
-pub fn search(task_config: &TaskTable) -> Result<SearchResults, Box<dyn Error>> {
+pub fn search(task_config: &TaskTable) -> Result<SearchReports, Box<dyn Error>> {
     let model = load_model(&task_config.model_path())?;
     let to_check = get_to_check_atom(
         &model,
@@ -48,7 +46,7 @@ pub fn search(task_config: &TaskTable) -> Result<SearchResults, Box<dyn Error>> 
     let site_index = SiteIndex::new(points);
     let search_config = SearchConfig::new(&to_check, task_config.target_bondlength());
     let search_report = search_sites(&site_index, &search_config);
-    Ok(search_sites)
+    Ok(search_report)
 }
 
 pub fn export_results_in_cell(

--- a/chemrust-nasl-app/src/execution/mod.rs
+++ b/chemrust-nasl-app/src/execution/mod.rs
@@ -9,7 +9,7 @@ use chemrust_core::data::{
 use chemrust_nasl::{search_sites, SearchConfig, SearchReports, SiteIndex};
 use nalgebra::Point3;
 
-use crate::yaml_parser::TaskTable;
+use crate::{error::RunError, yaml_parser::TaskTable};
 
 use self::{
     export::export_all,
@@ -46,7 +46,16 @@ pub fn search(task_config: &TaskTable) -> Result<SearchReports, Box<dyn Error>> 
     let site_index = SiteIndex::new(points);
     let search_config = SearchConfig::new(&to_check, task_config.target_bondlength());
     let search_report = search_sites(&site_index, &search_config);
-    Ok(search_report)
+    if search_report.viable_single_points().is_none()
+        && search_report.viable_double_points().is_none()
+        && search_report.points().is_none()
+    {
+        Err(Box::new(RunError::Message(
+            "No available results for this config.".to_string(),
+        )))
+    } else {
+        Ok(search_report)
+    }
 }
 
 pub fn export_results_in_cell(

--- a/chemrust-nasl-app/src/main.rs
+++ b/chemrust-nasl-app/src/main.rs
@@ -3,7 +3,6 @@ use std::{error::Error, fs};
 
 use arg_parser::ProgramMode;
 use clap::Parser;
-use error::RunError;
 use interactive_ui::RunOptions;
 
 use crate::{
@@ -33,18 +32,11 @@ fn run_by_config(yaml_config_path: Option<String>) -> Result<(), Box<dyn Error>>
     let filepath = yaml_config_path.unwrap_or("config.yaml".to_string());
     let yaml_table = TaskTable::load_task_table(filepath)?;
     let results = search(&yaml_table)?;
-    match results {
-        chemrust_nasl::SearchResults::Found(report) => {
-            println!(
-                "Successful. Results have been written to {}",
-                yaml_table.export_dir()
-            );
-            export_results_in_cell(&yaml_table, &report)
-        }
-        chemrust_nasl::SearchResults::Empty => {
-            Err(RunError::Message("No results for this config".to_string()))?
-        }
-    }
+    println!(
+        "Successful. Results have been written to {}",
+        yaml_table.export_dir()
+    );
+    export_results_in_cell(&yaml_table, &results)
 }
 
 fn interactive_cli() -> Result<(), Box<dyn Error>> {
@@ -52,14 +44,11 @@ fn interactive_cli() -> Result<(), Box<dyn Error>> {
     let run_options = RunOptions::new().unwrap();
     let yaml_table = run_options.export_config()?;
     let results = search(&yaml_table)?;
-    match results {
-        chemrust_nasl::SearchResults::Found(report) => {
-            export_results_in_cell(&yaml_table, &report)?
-        }
-        chemrust_nasl::SearchResults::Empty => {
-            Err(RunError::Message("No results for this config".to_string()))?
-        }
-    }
+    println!(
+        "Successful. Results have been written to {}",
+        yaml_table.export_dir()
+    );
+    export_results_in_cell(&yaml_table, &results)?;
     let export_table_filename = format!(
         "{}/{}.yaml",
         yaml_table.export_dir(),

--- a/chemrust-nasl/Cargo.toml
+++ b/chemrust-nasl/Cargo.toml
@@ -17,6 +17,7 @@ chemrust-core = {git = "https://github.com/TonyWu20/chemrust", branch = "refacto
 nalgebra = "0.32"
 kiddo = "4.2"
 castep-periodic-table = "0.4"
+rayon = "1.10"
 
 [dev-dependencies]
 castep-cell-io = "0.1"

--- a/chemrust-nasl/src/algorithm/mod.rs
+++ b/chemrust-nasl/src/algorithm/mod.rs
@@ -143,7 +143,6 @@ fn search_special_sites(
         site_index,
         search_config,
     );
-    let pure_circles = circle_check_results.circles();
     let points = [
         sphere_intersect_results.single_points(),
         circle_check_results.points(),
@@ -247,77 +246,6 @@ fn brute_force(
     match p {
         ControlFlow::Continue(_) => None,
         ControlFlow::Break(point) => Some(point),
-    }
-}
-
-fn try_get_single_point(
-    origin: Point3<f64>,
-    dist: f64,
-    kdtree: &ImmutableKdTree<f64, 3>,
-) -> Option<Point3<f64>> {
-    let init_direction: UnitVector3<f64> = Vector3::z_axis();
-    let mut step_angle = FRAC_PI_2;
-    let mut p: Option<Point3<f64>> = None;
-    let max_iteration: u32 = 1;
-    let mut counter: u32 = 0;
-    let reference_point = origin + init_direction.scale(dist);
-    while counter < max_iteration {
-        if let Some(point) =
-            recursive_search(origin, init_direction, dist, kdtree, reference_point, true)
-        {
-            p = Some(point);
-            break;
-        } else {
-            dbg!(counter);
-            step_angle /= 2.0;
-            counter += 1;
-        }
-    }
-    // #[cfg(debug_assertions)]
-    // {
-    dbg!(counter);
-    // }
-    p
-}
-
-fn recursive_search(
-    origin: Point3<f64>,
-    direction: UnitVector3<f64>,
-    dist: f64,
-    kdtree: &ImmutableKdTree<f64, 3>,
-    reference_point: Point3<f64>,
-    init: bool,
-) -> Option<Point3<f64>> {
-    if let FloatOrdering::Less = approx_cmp_f64(direction.z, 0.0) {
-        return None;
-    }
-    let new_point = origin + direction.scale(dist);
-    let cmp = approx_eq_point_f64(new_point, reference_point);
-    let is_same = match cmp {
-        FloatEq::NotEq => false,
-        FloatEq::Eq => true,
-    };
-    if !init && is_same {
-        dbg!("same");
-        return None;
-    }
-    if kdtree
-        .within::<SquaredEuclidean>(&new_point.into(), (dist + 10_f64 * EPSILON).powi(2))
-        .iter()
-        .any(|nb| {
-            matches!(
-                approx_cmp_f64(nb.distance, dist.powi(2)),
-                FloatOrdering::Less
-            )
-        })
-    {
-        None
-    } else {
-        #[cfg(debug_assertions)]
-        {
-            dbg!("Yes");
-        }
-        Some(new_point)
     }
 }
 

--- a/chemrust-nasl/src/algorithm/mod.rs
+++ b/chemrust-nasl/src/algorithm/mod.rs
@@ -1,13 +1,10 @@
 use std::{
-    f64::{
-        consts::{FRAC_PI_2, FRAC_PI_8},
-        EPSILON,
-    },
+    f64::{consts::FRAC_PI_8, EPSILON},
     ops::ControlFlow,
 };
 
 use kiddo::{ImmutableKdTree, SquaredEuclidean};
-use nalgebra::{Point3, UnitVector3, Vector3};
+use nalgebra::{Point3, Vector3};
 use rayon::prelude::*;
 
 use self::{
@@ -16,10 +13,9 @@ use self::{
 };
 
 use crate::{
-    approx_eq_point_f64,
     coordination_sites::{CoordCircle, MultiCoordPoint},
     geometry::{approx_cmp_f64, FloatOrdering},
-    DelegatePoint, FloatEq, Visualize,
+    DelegatePoint, Visualize,
 };
 
 mod circle_check;

--- a/chemrust-nasl/src/algorithm/mod.rs
+++ b/chemrust-nasl/src/algorithm/mod.rs
@@ -17,7 +17,7 @@ use self::{
 
 use crate::{
     approx_eq_point_f64,
-    coordination_sites::{CoordCircle, CoordSphere, MultiCoordPoint},
+    coordination_sites::{CoordCircle, MultiCoordPoint},
     geometry::{approx_cmp_f64, FloatOrdering},
     DelegatePoint, FloatEq, Visualize,
 };

--- a/chemrust-nasl/src/algorithm/sphere_check.rs
+++ b/chemrust-nasl/src/algorithm/sphere_check.rs
@@ -6,18 +6,18 @@ use crate::geometry::{Intersect, Sphere, SphereSphereResult};
 
 use super::{SearchConfig, SiteIndex};
 
-use crate::coordination_sites::{CoordCircle, CoordPoint, CoordResult, CoordSphere};
+use crate::coordination_sites::{CoordCircle, CoordResult, CoordSphere, MultiCoordPoint};
 
 #[derive(Debug)]
-pub struct SphereCheckResult {
-    single_points: Vec<CoordPoint>,
+pub(crate) struct SphereCheckResult {
+    single_points: Vec<MultiCoordPoint>,
     unchecked_circles: Vec<CoordCircle>,
     spheres: Vec<CoordSphere>,
 }
 
 impl SphereCheckResult {
     pub fn new(
-        single_points: Vec<CoordPoint>,
+        single_points: Vec<MultiCoordPoint>,
         unchecked_circles: Vec<CoordCircle>,
         spheres: Vec<CoordSphere>,
     ) -> Self {
@@ -28,7 +28,7 @@ impl SphereCheckResult {
         }
     }
 
-    pub fn single_points(&self) -> &[CoordPoint] {
+    pub fn single_points(&self) -> &[MultiCoordPoint] {
         self.single_points.as_ref()
     }
 
@@ -74,7 +74,7 @@ pub fn sphere_check(site_index: &SiteIndex, search_config: &SearchConfig) -> Sph
                                 match sphere.intersect(&nb_sphere) {
                                     SphereSphereResult::Empty => None,
                                     SphereSphereResult::Point(p) => {
-                                        let coord_point = CoordPoint::new(p, id_pair.to_vec());
+                                        let coord_point = MultiCoordPoint::new(p, id_pair.to_vec());
                                         coord_point
                                             .no_closer_atoms(
                                                 site_index.coord_tree(),
@@ -105,7 +105,7 @@ pub fn sphere_check(site_index: &SiteIndex, search_config: &SearchConfig) -> Sph
         .iter()
         .filter_map(|res| res.try_pull_circles_from_various().ok())
         .collect();
-    let points: Vec<Vec<CoordPoint>> = results
+    let points: Vec<Vec<MultiCoordPoint>> = results
         .iter_mut()
         .filter_map(|res| res.try_pull_single_points_from_various().ok())
         .collect();

--- a/chemrust-nasl/src/algorithm/test.rs
+++ b/chemrust-nasl/src/algorithm/test.rs
@@ -1,9 +1,4 @@
-use std::{
-    f64::{consts::FRAC_PI_4, EPSILON},
-    fs::read_to_string,
-    ops::ControlFlow,
-    path::Path,
-};
+use std::{fs::read_to_string, path::Path};
 
 use castep_cell_io::{CellDocument, CellParser, LatticeParam};
 
@@ -15,15 +10,9 @@ use chemrust_core::data::{
         CrystalModel, LatticeCell,
     },
 };
-use kiddo::{ImmutableKdTree, SquaredEuclidean};
-use nalgebra::{Matrix3, Point3, Rotation3, UnitVector3, Vector3};
+use nalgebra::{Matrix3, Point3, Vector3};
 
-use crate::{
-    geometry::{approx_cmp_f64, FloatOrdering},
-    search_sites, SearchReports,
-};
-
-use super::{search_special_sites, SearchConfig, SiteIndex};
+use crate::{search_sites, SearchConfig, SearchReports, SiteIndex};
 
 fn load_model(model_rel_path: &str) -> Option<LatticeCell> {
     let root_dir = env!("CARGO_MANIFEST_DIR");

--- a/chemrust-nasl/src/coordination_sites/coord_circle.rs
+++ b/chemrust-nasl/src/coordination_sites/coord_circle.rs
@@ -1,9 +1,6 @@
 use std::{
     collections::HashSet,
-    f64::{
-        consts::{FRAC_PI_2, FRAC_PI_8},
-        EPSILON,
-    },
+    f64::consts::{FRAC_PI_2, FRAC_PI_8},
     ops::ControlFlow,
 };
 
@@ -39,17 +36,19 @@ impl CoordCircle {
             .collect();
         let p = possible_position.iter().try_for_each(|&theta| {
             let query = self.circle().get_point_on_circle(theta);
-            if !kdtree
-                .within::<SquaredEuclidean>(&query.into(), (dist + 10_f64 * EPSILON).powi(2))
-                .iter()
-                .any(|nb| {
-                    matches!(
-                        approx_cmp_f64(nb.distance, dist.powi(2)),
-                        FloatOrdering::Less
-                    )
-                })
-            {
-                ControlFlow::Break(query)
+            let neighbours =
+                kdtree.within::<SquaredEuclidean>(&query.into(), (dist + 1e-5_f64).powi(2));
+            if !neighbours.iter().any(|nb| {
+                matches!(
+                    approx_cmp_f64(nb.distance, dist.powi(2)),
+                    FloatOrdering::Less
+                )
+            }) {
+                if neighbours.len() <= 2 {
+                    ControlFlow::Break(query)
+                } else {
+                    ControlFlow::Continue(())
+                }
             } else {
                 ControlFlow::Continue(())
             }

--- a/chemrust-nasl/src/coordination_sites/coord_circle.rs
+++ b/chemrust-nasl/src/coordination_sites/coord_circle.rs
@@ -37,7 +37,7 @@ impl CoordCircle {
         let possible_position: Vec<f64> = (0..32)
             .map(|i| FRAC_PI_2 + i as f64 * step_frac_pi_32)
             .collect();
-        let p = possible_position.iter().try_for_each(|theta| {
+        let p = possible_position.iter().try_for_each(|&theta| {
             let query = self.circle().get_point_on_circle(theta);
             if !kdtree
                 .within::<SquaredEuclidean>(&query.into(), (dist + 10_f64 * EPSILON).powi(2))

--- a/chemrust-nasl/src/coordination_sites/mod.rs
+++ b/chemrust-nasl/src/coordination_sites/mod.rs
@@ -60,7 +60,7 @@ impl CoordSite for MultiCoordPoint {
 
 impl CoordSite for DelegatePoint<1> {
     fn connecting_atoms_msg(&self) -> String {
-        format!("single_{}", self.atom_ids)
+        format!("single_{}", self.atom_ids[0])
     }
 
     fn site_type(&self) -> String {

--- a/chemrust-nasl/src/coordination_sites/visualize.rs
+++ b/chemrust-nasl/src/coordination_sites/visualize.rs
@@ -2,7 +2,7 @@ use std::f64::consts::FRAC_PI_2;
 
 use castep_periodic_table::element::ElementSymbol;
 use chemrust_core::data::geom::coordinates::CoordData;
-use nalgebra::{Matrix3, Point3, UnitVector3, Vector3};
+use nalgebra::{Matrix3, Point3, Vector3};
 
 use crate::DelegatePoint;
 

--- a/chemrust-nasl/src/coordination_sites/visualize.rs
+++ b/chemrust-nasl/src/coordination_sites/visualize.rs
@@ -1,8 +1,12 @@
+use std::f64::consts::FRAC_PI_2;
+
 use castep_periodic_table::element::ElementSymbol;
 use chemrust_core::data::geom::coordinates::CoordData;
 use nalgebra::{Matrix3, Point3, UnitVector3, Vector3};
 
-use super::{CoordCircle, CoordPoint, CoordSphere};
+use crate::DelegatePoint;
+
+use super::{CoordCircle, CoordSphere, MultiCoordPoint};
 
 pub trait Visualize {
     type Output;
@@ -60,17 +64,7 @@ impl Visualize for CoordCircle {
     }
 
     fn determine_coord(&self) -> Point3<f64> {
-        let (x, y, _z) = (self.circle.n().x, self.circle.n().y, self.circle.n().z);
-        // We want the v2 to act as the "z-axis" after transformation
-        let pre_v1 = Vector3::new(-1.0 * y, x, 0.0);
-        let v1 = if pre_v1.norm_squared() < f64::EPSILON {
-            // such v1 becomes a null vector when the normal is (0, 0, z)
-            Vector3::x_axis()
-        } else {
-            UnitVector3::new_normalize(pre_v1)
-        };
-        let v2 = self.circle.n().cross(&v1);
-        self.circle.center() + (v1.scale(0.0) + v2.scale(1.0)).scale(self.circle.radius())
+        self.circle().get_point_on_circle(FRAC_PI_2)
     }
 
     fn element_by_cn_number(&self) -> ElementSymbol {
@@ -78,7 +72,7 @@ impl Visualize for CoordCircle {
     }
 }
 
-impl Visualize for CoordPoint {
+impl Visualize for MultiCoordPoint {
     type Output = Atom;
 
     fn draw_with_element(&self, element_symbol: ElementSymbol) -> Self::Output {
@@ -95,5 +89,21 @@ impl Visualize for CoordPoint {
         } else {
             ElementSymbol::Np
         }
+    }
+}
+
+impl<const N: usize> Visualize for DelegatePoint<N> {
+    type Output = Atom;
+
+    fn determine_coord(&self) -> Point3<f64> {
+        self.point
+    }
+
+    fn element_by_cn_number(&self) -> ElementSymbol {
+        ElementSymbol::Xe
+    }
+
+    fn draw_with_element(&self, element_symbol: ElementSymbol) -> Self::Output {
+        Atom::new(element_symbol, CoordData::Cartesian(self.determine_coord()))
     }
 }

--- a/chemrust-nasl/src/geometry/intersections/mod.rs
+++ b/chemrust-nasl/src/geometry/intersections/mod.rs
@@ -37,7 +37,7 @@ pub fn approx_eq_point_f64(p1: Point3<f64>, p2: Point3<f64>) -> FloatEq {
     let d = p1 - p2;
     // Δx, Δy, Δz < ϵ
     // (Δx^2 + Δy^2 + Δz^2 < 3ϵ^2)
-    if d.norm_squared() < 3.0 * (1.0e-8_f64).powi(2) {
+    if d.norm_squared() < 3.0 * (1.0e-5_f64).powi(2) {
         FloatEq::Eq
     } else {
         FloatEq::NotEq

--- a/chemrust-nasl/src/geometry/primitives/circle/mod.rs
+++ b/chemrust-nasl/src/geometry/primitives/circle/mod.rs
@@ -1,4 +1,4 @@
-use nalgebra::{Point3, UnitVector3};
+use nalgebra::{Point3, UnitVector3, Vector3};
 
 use super::plane::Plane;
 
@@ -39,5 +39,19 @@ impl Circle3d {
         let min_dist = (min_x.powi(2) + op_projection_height.powi(2)).sqrt();
         let max_dist = (max_x.powi(2) + op_projection_height.powi(2)).sqrt();
         (min_dist, max_dist)
+    }
+
+    pub fn get_point_on_circle(&self, theta: f64) -> Point3<f64> {
+        let (x, y, _z) = (self.n().x, self.n().y, self.n().z);
+        // We want the v2 to act as the "z-axis" after transformation
+        let pre_v1 = Vector3::new(-1.0 * y, x, 0.0);
+        let v1 = if pre_v1.norm_squared() < f64::EPSILON {
+            // such v1 becomes a null vector when the normal is (0, 0, z)
+            Vector3::x_axis()
+        } else {
+            UnitVector3::new_normalize(pre_v1)
+        };
+        let v2 = self.n().cross(&v1);
+        self.center() + (v1.scale(theta.cos()) + v2.scale(theta.sin())).scale(self.radius())
     }
 }

--- a/chemrust-nasl/src/lib.rs
+++ b/chemrust-nasl/src/lib.rs
@@ -3,5 +3,6 @@ mod algorithm;
 mod coordination_sites;
 mod geometry;
 
-pub use algorithm::{search_sites, SearchConfig, SearchReports, SearchResults, SiteIndex};
+pub use algorithm::{search_sites, SearchConfig, SearchReports, SiteIndex};
 pub use coordination_sites::*;
+pub use geometry::*;


### PR DESCRIPTION
- **Add `get_point_on_circle`**
- **Generic struct of `DelegatePoint` to represent coords with less than 3 members**
- **Generic struct of `DelegatePoint` to represent coords with less than 3 members**
- **Generic struct of `DelegatePoint` to represent coords with less than 3 members**
- **Use `get_point_on_circle` to export possible outcome of the circle**
- **Export viable single and double points**
- **Export viable single and double points**
- **Export viable single and double points**
- **Change of `MultiCoordPoint`**
- **Change of `MultiCoordPoint`**
- **Adjust test**
- **Change of `MultiCoordPoint`**
- **Fix**
- **Fix**
- **Apply changes to pub-exported modules**
- **Introduce rayon**
- **Apply changes to pub-exported modules**
- **Apply changes to pub-exported modules**
- **Add helper function `boundary_check`**
- **Fixed**
- **Bump version**
- **Apply changes to pub-exported modules**
- **Remove unused codes**
- **Remove unused codes**
- **Prevent repeated results to multipoints**
- **Fixed little**
